### PR TITLE
Added roundPixels option to both Renderers

### DIFF
--- a/src/pixi/Pixi.js
+++ b/src/pixi/Pixi.js
@@ -171,6 +171,7 @@ PIXI.dontSayHello = false;
  * @property {Number} defaultRenderOptions.resolution=1
  * @property {Boolean} defaultRenderOptions.clearBeforeRender=true
  * @property {Boolean} defaultRenderOptions.autoResize=false
+ * @property {Boolean} defaultRenderOptions.roundPixels=false 
  * @static
  */
 PIXI.defaultRenderOptions = {
@@ -180,7 +181,8 @@ PIXI.defaultRenderOptions = {
     preserveDrawingBuffer:false,
     resolution:1,
     clearBeforeRender:true,
-    autoResize:false
+    autoResize:false,
+    roundPixels:false
 }
 
 PIXI.sayHello = function (type)

--- a/src/pixi/renderers/canvas/CanvasRenderer.js
+++ b/src/pixi/renderers/canvas/CanvasRenderer.js
@@ -16,6 +16,7 @@
  * @param [options.autoResize=false] {Boolean} If the render view is automatically resized, default false
  * @param [options.resolution=1] {Number} the resolution of the renderer retina would be 2
  * @param [options.clearBeforeRender=true] {Boolean} This sets if the CanvasRenderer will clear the canvas or not before the new render pass.
+ * @param [options.roundPixels=false] {Boolean} If true Pixi will round x/y values when rendering, stopping pixel interpolation.
  */
 PIXI.CanvasRenderer = function(width, height, options)
 {
@@ -159,7 +160,7 @@ PIXI.CanvasRenderer = function(width, height, options)
          * Handy for crisp pixel art and speed on legacy devices.
          *
          */
-        roundPixels: false
+        roundPixels: options.roundPixels
     };
 
     this.mapBlendModes();

--- a/src/pixi/renderers/webgl/WebGLRenderer.js
+++ b/src/pixi/renderers/webgl/WebGLRenderer.js
@@ -22,6 +22,7 @@ PIXI.instances = [];
  * @param [options.antialias=false] {Boolean} sets antialias (only applicable in chrome at the moment)
  * @param [options.preserveDrawingBuffer=false] {Boolean} enables drawing buffer preservation, enable this if you need to call toDataUrl on the webgl context
  * @param [options.resolution=1] {Number} the resolution of the renderer retina would be 2
+ * @param [options.roundPixels=false] {Boolean} If true Pixi will round x/y values when rendering, stopping pixel interpolation.
  */
 PIXI.WebGLRenderer = function(width, height, options)
 {
@@ -224,6 +225,7 @@ PIXI.WebGLRenderer = function(width, height, options)
     this.renderSession.stencilManager = this.stencilManager;
     this.renderSession.renderer = this;
     this.renderSession.resolution = this.resolution;
+    this.renderSession.roundPixels = this.roundPixels;
 
     // time init the context..
     this.initContext();


### PR DESCRIPTION
Added a "roundPixels" option to both WebGLRenderer and CanvasRenderer. It's then set to the renderSession.roundPixels property, which was used, but always set to false. 
